### PR TITLE
Obs build fixes

### DIFF
--- a/3rdParty/hyperscan/CMakeLists.txt
+++ b/3rdParty/hyperscan/CMakeLists.txt
@@ -396,7 +396,7 @@ SET(hs_HEADERS
     src/hs_compile.h
     src/hs_runtime.h
 )
-install(FILES ${hs_HEADERS} DESTINATION include/hs)
+#install(FILES ${hs_HEADERS} DESTINATION include/hs)
 
 set (hs_exec_SRCS
     ${hs_HEADERS}
@@ -968,7 +968,7 @@ add_library(hs_runtime STATIC src/hs_version.c $<TARGET_OBJECTS:hs_exec>)
 set_target_properties(hs_runtime PROPERTIES
     LINKER_LANGUAGE C)
 if (NOT BUILD_SHARED_LIBS)
-    install(TARGETS hs_runtime DESTINATION lib)
+#    install(TARGETS hs_runtime DESTINATION lib)
 endif()
 
 if (BUILD_STATIC_AND_SHARED OR BUILD_SHARED_LIBS)
@@ -979,10 +979,10 @@ if (BUILD_STATIC_AND_SHARED OR BUILD_SHARED_LIBS)
         OUTPUT_NAME hs_runtime
         MACOSX_RPATH ON
         LINKER_LANGUAGE C)
-    install(TARGETS hs_runtime_shared
-        RUNTIME DESTINATION bin
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+#    install(TARGETS hs_runtime_shared
+#        RUNTIME DESTINATION bin
+#        ARCHIVE DESTINATION lib
+#        LIBRARY DESTINATION lib)
 endif()
 
 # we want the static lib for testing
@@ -993,7 +993,7 @@ add_dependencies(hs ragel_Parser)
 ENDIF (WITH_RAGEL STREQUAL "YES")
 
 if (NOT BUILD_SHARED_LIBS)
-install(TARGETS hs DESTINATION lib)
+#install(TARGETS hs DESTINATION lib)
 endif()
 
 if (BUILD_STATIC_AND_SHARED OR BUILD_SHARED_LIBS)
@@ -1006,10 +1006,10 @@ if (BUILD_STATIC_AND_SHARED OR BUILD_SHARED_LIBS)
         VERSION ${LIB_VERSION}
         SOVERSION ${LIB_SOVERSION}
         MACOSX_RPATH ON)
-install(TARGETS hs_shared
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib)
+#install(TARGETS hs_shared
+#    RUNTIME DESTINATION bin
+#    ARCHIVE DESTINATION lib
+#    LIBRARY DESTINATION lib)
 endif()
 
 #EXCLUDED if(NOT WIN32)

--- a/dist/archlinux/PKGBUILD.in
+++ b/dist/archlinux/PKGBUILD.in
@@ -3,6 +3,7 @@
 
 pkgname=struspattern
 _mainpkgver=@STRUS_VERSION@
+_deppkgver=@STRUS_MAJOR_VERSION@.@STRUS_MINOR_VERSION@
 pkgver=${_mainpkgver}
 pkgrel=1
 pkgdesc='Library implementing pattern matching on text for document and query analysis.'

--- a/dist/archlinux/PKGBUILD.in
+++ b/dist/archlinux/PKGBUILD.in
@@ -10,7 +10,7 @@ pkgdesc='Library implementing pattern matching on text for document and query an
 license=('MPL2')
 arch=('i686' 'x86_64')
 url="http://project-strus.net"
-depends=('boost>=1.53' 'boost-libs>=1.53' "strusbase>=${_deppkgver}" "strus=${_deppkgver}" "strusanalyzer>=${_deppkgver}" "strustrace>=${_deppkgver}" "strusmodule>=${_deppkgver}")
+depends=('boost>=1.53' 'boost-libs>=1.53' "strusbase>=${_deppkgver}" "strus>=${_deppkgver}" "strusanalyzer>=${_deppkgver}" "strustrace>=${_deppkgver}" "strusmodule>=${_deppkgver}")
 makedepends=('cmake')
 source=("${pkgname}-${_mainpkgver}.tar.gz")
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost-dev, libboost-thread-dev, libboost-system-dev,
- libboost-date-time-dev, strusbase-dev, strus-dev,
- strusanalyzer-dev, strustrace-dev, strusmodule-dev
+ libboost-date-time-dev, libboost-regex-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Standards-Version: 3.8.3
 Homepage: http://project-strus.net
 

--- a/dist/obs/control-Debian_7.0
+++ b/dist/obs/control-Debian_7.0
@@ -4,9 +4,8 @@ Priority: optional
 Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev,
- strusbase-dev, strus-dev, strusanalyzer-dev,
- strustrace-dev, strusmodule-dev
+ libboost-date-time1.53-dev, libboost-regex1.53-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Standards-Version: 3.8.3
 Homepage: http://project-strus.net
 

--- a/dist/obs/control-xUbuntu_12.04
+++ b/dist/obs/control-xUbuntu_12.04
@@ -4,9 +4,8 @@ Priority: optional
 Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev,
- strusbase-dev, strus-dev, strusanalyzer-dev,
- strustrace-dev, strusmodule-dev
+ libboost-date-time1.53-dev, libboost-regex1.53-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Standards-Version: 3.8.3
 Homepage: http://project-strus.net
 

--- a/dist/obs/struspattern-Debian_7.0.dsc.in
+++ b/dist/obs/struspattern-Debian_7.0.dsc.in
@@ -6,6 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev, strusbase-dev, strus-dev,
- strusanalyzer-dev, strustrace-dev, strusmodule-dev
+ libboost-date-time1.53-dev, libboost-regex1.53-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/obs/struspattern-Debian_7.0.dsc.in
+++ b/dist/obs/struspattern-Debian_7.0.dsc.in
@@ -6,5 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev, strusbase-dev, strusanalyzer-dev
+ libboost-date-time1.53-dev, strusbase-dev, strus-dev,
+ strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/obs/struspattern-xUbuntu_12.04.dsc.in
+++ b/dist/obs/struspattern-xUbuntu_12.04.dsc.in
@@ -6,6 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev, strusbase-dev, strus-dev,
- strusanalyzer-dev, strustrace-dev, strusmodule-dev
+ libboost-date-time1.53-dev, libboost-regex1.53-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/obs/struspattern-xUbuntu_12.04.dsc.in
+++ b/dist/obs/struspattern-xUbuntu_12.04.dsc.in
@@ -6,5 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost1.53-dev, libboost-thread1.53-dev, libboost-system1.53-dev,
- libboost-date-time1.53-dev, strusbase-dev, strusanalyzer-dev
+ libboost-date-time1.53-dev, strusbase-dev, strus-dev,
+ strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/obs/struspattern.dsc.in
+++ b/dist/obs/struspattern.dsc.in
@@ -6,6 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost-dev, libboost-thread-dev, libboost-system-dev,
- libboost-date-time-dev, strusbase-dev, strus-dev,
- strusanalyzer-dev, strustrace-dev, strusmodule-dev
+ libboost-date-time-dev, libboost-regex-dev, strusbase-dev,
+ strus-dev, strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/obs/struspattern.dsc.in
+++ b/dist/obs/struspattern.dsc.in
@@ -6,5 +6,6 @@ Maintainer: Patrick Frey <patrickpfrey@yahoo.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake,
  libboost-dev, libboost-thread-dev, libboost-system-dev,
- libboost-date-time-dev, strusbase-dev, strusanalyzer-dev
+ libboost-date-time-dev, strusbase-dev, strus-dev,
+ strusanalyzer-dev, strustrace-dev, strusmodule-dev
 Files:

--- a/dist/redhat/struspattern.spec.in
+++ b/dist/redhat/struspattern.spec.in
@@ -199,10 +199,10 @@ Requires: libboost_date_time1_54_0 >= 1.54.0
 BuildRequires: boost-devel
 %endif
 %if %{osufactory}
-Requires: libboost_thread1_60_0 >= 1.60.0
-Requires: libboost_atomic1_60_0 >= 1.60.0
-Requires: libboost_system1_60_0 >= 1.60.0
-Requires: libboost_date_time1_60_0 >= 1.60.0
+Requires: libboost_thread1_61_0 >= 1.61.0
+Requires: libboost_atomic1_61_0 >= 1.61.0
+Requires: libboost_system1_61_0 >= 1.61.0
+Requires: libboost_date_time1_61_0 >= 1.61.0
 BuildRequires: boost-devel
 %endif
 %endif

--- a/dist/redhat/struspattern.spec.in
+++ b/dist/redhat/struspattern.spec.in
@@ -65,16 +65,16 @@
 %endif
 
 %define fedora 0
-%define fc22 0
 %define fc23 0
-%if 0%{?fedora_version} == 22
-%define dist fc22
-%define fc22 1
-%define fedora 1
-%endif
+%define fc24 0
 %if 0%{?fedora_version} == 23
 %define dist fc23
 %define fc23 1
+%define fedora 1
+%endif
+%if 0%{?fedora_version} == 24
+%define dist fc24
+%define fc24 1
 %define fedora 1
 %endif
 

--- a/dist/redhat/struspattern.spec.in
+++ b/dist/redhat/struspattern.spec.in
@@ -187,6 +187,7 @@ Requires: libboost_thread1_53_0 >= 1.53.0
 Requires: libboost_atomic1_53_0 >= 1.53.0
 Requires: libboost_system1_53_0 >= 1.53.0
 Requires: libboost_date_time1_53_0 >= 1.53.0
+Requires: libboost_regex1_53_0 >= 1.53.0
 BuildRequires: boost-devel
 # for some reason OBS doesn't pull in libboost_atomic1_53_0 automatically!?
 BuildRequires: libboost_atomic1_53_0 >= 1.53.0
@@ -196,6 +197,7 @@ Requires: libboost_thread1_54_0 >= 1.54.0
 Requires: libboost_atomic1_54_0 >= 1.54.0
 Requires: libboost_system1_54_0 >= 1.54.0
 Requires: libboost_date_time1_54_0 >= 1.54.0
+Requires: libboost_regex1_54_0 >= 1.54.0
 BuildRequires: boost-devel
 %endif
 %if %{osufactory}
@@ -203,6 +205,7 @@ Requires: libboost_thread1_61_0 >= 1.61.0
 Requires: libboost_atomic1_61_0 >= 1.61.0
 Requires: libboost_system1_61_0 >= 1.61.0
 Requires: libboost_date_time1_61_0 >= 1.61.0
+Requires: libboost_regex1_61_0 >= 1.61.0
 BuildRequires: boost-devel
 %endif
 %endif

--- a/dist/redhat/struspattern.spec.in
+++ b/dist/redhat/struspattern.spec.in
@@ -287,8 +287,6 @@ make test
 %{_includedir}/strus/*.hpp
 %dir %{_includedir}/strus/lib
 %{_includedir}/strus/lib/*.hpp
-%dir %{_includedir}/strus/base
-%{_includedir}/strus/base/*.hpp
 
 %changelog
 * Sat Oct 1 2016 Patrick Frey <patrickpfrey@yahoo.com> 0.12.0-0.1


### PR DESCRIPTION
In details:
- fedora 23 and 24
- boost 1.61 Tumbleweed
- non-installation of hs library (static library and header files)
- boost regex is needed by parts of hs it seems (at least it's probed in `cmake/boost.cmake`.
- fixes for OBS exclude C++11 support and cloud machines which don't have SSSE3 support
  (this is quite random, every build results on other machines, no clue, how to fix this)
